### PR TITLE
Setting the default timezone to make tests worked

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,2 +1,3 @@
 <?php
 
+date_default_timezone_set('UTC');


### PR DESCRIPTION
As title, setting the default timezone during tests running to make them worked successfully.

The default timezone in the system-wide might not be the `UTC` and tests will be failed.

For example, when my timezone is `Asia/Taipei` in my development environment, running tests will present the following failed message:

```
Time: 00:00.036, Memory: 12.00 MB

There was 1 failure:

---------
1) SchematorTest: Format
 Test  tests/unit/SchematorTest.php:testFormat
Failed asserting that two strings are equal.
- Expected | + Actual
@@ @@
-'2022-04-28'
+'2022-04-29'
#1  /home/localadmin/schemator-php/tests/unit/SchematorTest.php:454
#2  /home/localadmin/schemator-php/vendor/bin/codecept:115

FAILURES!
Tests: 14, Assertions: 157, Failures: 1.
Script ./vendor/bin/codecept run unit tests/unit handling the test event returned with error code 1
```